### PR TITLE
Provide smarter output on the client, fixes #77

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/src/main/java/org/jboss/fuse/mvnd/common/Message.java
+++ b/common/src/main/java/org/jboss/fuse/mvnd/common/Message.java
@@ -146,14 +146,20 @@ public abstract class Message {
     }
 
     public static class BuildMessage extends Message {
+        final String projectId;
         final String message;
 
-        public BuildMessage(String message) {
+        public BuildMessage(String projectId, String message) {
+            this.projectId = projectId;
             this.message = message;
         }
 
         public String getMessage() {
             return message;
+        }
+
+        public String getProjectId() {
+            return projectId;
         }
 
         @Override
@@ -236,11 +242,13 @@ public abstract class Message {
         }
 
         private BuildMessage readBuildMessage(DataInputStream input) throws IOException {
+            String projectId = readUTF(input);
             String message = readUTF(input);
-            return new BuildMessage(message);
+            return new BuildMessage(projectId.isEmpty() ? null : projectId, message);
         }
 
         private void writeBuildMessage(DataOutputStream output, BuildMessage value) throws IOException {
+            writeUTF(output, value.projectId != null ? value.projectId : "");
             writeUTF(output, value.message);
         }
 

--- a/integration-tests/src/test/java/org/jboss/fuse/mvnd/assertj/MatchInOrderAmongOthers.java
+++ b/integration-tests/src/test/java/org/jboss/fuse/mvnd/assertj/MatchInOrderAmongOthers.java
@@ -17,6 +17,7 @@ package org.jboss.fuse.mvnd.assertj;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,7 +44,7 @@ public class MatchInOrderAmongOthers<T extends List<? extends String>> extends C
                                 .filter(pat -> pat.matcher(m).find())
                                 .findFirst()
                                 .orElse(null))
-                        .filter(pat -> pat != null) /* remove null patterns */
+                        .filter(Objects::nonNull) /* remove null patterns */
                         .collect(Collectors.toList())
                         /* if the mapped patterns equal the input patterns then each pattern matched exactly once */
                         .equals(patterns),

--- a/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/MultiModuleTest.java
+++ b/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/MultiModuleTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
+
 @MvndTest(projectDir = "src/test/projects/multi-module")
 public class MultiModuleTest {
 
@@ -71,7 +73,7 @@ public class MultiModuleTest {
         client.execute(output, "clean", "install", "-e").assertSuccess();
 
         final ArgumentCaptor<String> logMessage = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(output, Mockito.atLeast(1)).accept(logMessage.capture());
+        Mockito.verify(output, Mockito.atLeast(1)).accept(any(), logMessage.capture());
         Assertions.assertThat(logMessage.getAllValues())
                 .satisfiesAnyOf( /* Two orderings are possible */
                         messages -> Assertions.assertThat(messages)

--- a/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/SingleModuleNativeIT.java
+++ b/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/SingleModuleNativeIT.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
+
 @MvndNativeTest(projectDir = "src/test/projects/single-module")
 public class SingleModuleNativeIT {
 
@@ -57,14 +59,14 @@ public class SingleModuleNativeIT {
         final Properties props = MvndTestUtil.properties(layout.multiModuleProjectDirectory().resolve("pom.xml"));
 
         final InOrder inOrder = Mockito.inOrder(o);
-        inOrder.verify(o).accept(Mockito.contains("Building single-module"));
-        inOrder.verify(o).accept(Mockito.contains(MvndTestUtil.plugin(props, "maven-clean-plugin") + ":clean"));
-        inOrder.verify(o).accept(Mockito.contains(MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":compile"));
-        inOrder.verify(o).accept(Mockito.contains(MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":testCompile"));
-        inOrder.verify(o).accept(Mockito.contains(MvndTestUtil.plugin(props, "maven-surefire-plugin") + ":test"));
-        inOrder.verify(o).accept(Mockito.contains(MvndTestUtil.plugin(props, "maven-install-plugin") + ":install"));
-        inOrder.verify(o)
-                .accept(Mockito.contains("SUCCESS build of project org.jboss.fuse.mvnd.test.single-module:single-module"));
+        inOrder.verify(o).accept(any(), Mockito.contains("Building single-module"));
+        inOrder.verify(o).accept(any(), Mockito.contains(MvndTestUtil.plugin(props, "maven-clean-plugin") + ":clean"));
+        inOrder.verify(o).accept(any(), Mockito.contains(MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":compile"));
+        inOrder.verify(o).accept(any(), Mockito.contains(MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":testCompile"));
+        inOrder.verify(o).accept(any(), Mockito.contains(MvndTestUtil.plugin(props, "maven-surefire-plugin") + ":test"));
+        inOrder.verify(o).accept(any(), Mockito.contains(MvndTestUtil.plugin(props, "maven-install-plugin") + ":install"));
+        inOrder.verify(o).accept(any(),
+                Mockito.contains("SUCCESS build of project org.jboss.fuse.mvnd.test.single-module:single-module"));
 
         assertJVM(o, props);
 

--- a/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/StopStatusTest.java
+++ b/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/StopStatusTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
+
 @MvndTest(projectDir = "src/test/projects/single-module")
 public class StopStatusTest {
 
@@ -54,7 +56,7 @@ public class StopStatusTest {
             final ClientOutput output = Mockito.mock(ClientOutput.class);
             client.execute(output, "--status").assertSuccess();
             final ArgumentCaptor<String> logMessage = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(output, Mockito.atLeast(1)).accept(logMessage.capture());
+            Mockito.verify(output, Mockito.atLeast(1)).accept(any(), logMessage.capture());
             Assertions.assertThat(logMessage.getAllValues())
                     .is(new MatchInOrderAmongOthers<>(
                             d.getUid() + " +" + d.getPid() + " +" + d.getAddress()));
@@ -76,7 +78,7 @@ public class StopStatusTest {
             final ClientOutput output = Mockito.mock(ClientOutput.class);
             client.execute(output, "--status").assertSuccess();
             final ArgumentCaptor<String> logMessage = ArgumentCaptor.forClass(String.class);
-            Mockito.verify(output, Mockito.atLeast(1)).accept(logMessage.capture());
+            Mockito.verify(output, Mockito.atLeast(1)).accept(any(), logMessage.capture());
             Assertions.assertThat(
                     logMessage.getAllValues().stream()
                             .filter(m -> m.contains(d.getUid()))

--- a/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/VersionNativeIT.java
+++ b/integration-tests/src/test/java/org/jboss/fuse/mvnd/it/VersionNativeIT.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
+
 @MvndNativeTest(projectDir = MvndTestExtension.TEMP_EXTERNAL)
 public class VersionNativeIT {
 
@@ -44,7 +46,7 @@ public class VersionNativeIT {
         client.execute(output, "-v").assertSuccess();
 
         final ArgumentCaptor<String> logMessage = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(output, Mockito.atLeast(1)).accept(logMessage.capture());
+        Mockito.verify(output, Mockito.atLeast(1)).accept(any(), logMessage.capture());
 
         Assertions.assertThat(logMessage.getAllValues())
                 .is(new MatchInOrderAmongOthers<>(


### PR DESCRIPTION
All events are directly forwarded to the client.  The client is now responsible for ordering them per project and displaying them if needed.  A thread is now started to read the terminal input with support for '+' to display one more line per project, '-' to display one line less, and 'Ctrl+L' to redraw the display which could become messed if the build messages are a bit unusual (this may require a better fix though).