### PR TITLE
Improve terminal output

### DIFF
--- a/client/src/main/java/org/jboss/fuse/mvnd/client/DefaultClient.java
+++ b/client/src/main/java/org/jboss/fuse/mvnd/client/DefaultClient.java
@@ -202,8 +202,7 @@ public class DefaultClient implements Client {
 
             final DaemonConnector connector = new DaemonConnector(layout, registry, buildProperties);
             List<String> opts = new ArrayList<>();
-            try (DaemonClientConnection daemon = connector.connect(new DaemonCompatibilitySpec(javaHome, opts),
-                    s -> output.accept(null, s))) {
+            try (DaemonClientConnection daemon = connector.connect(new DaemonCompatibilitySpec(javaHome, opts), output)) {
 
                 daemon.dispatch(new Message.BuildRequest(
                         args,

--- a/common/src/main/java/org/jboss/fuse/mvnd/common/logging/ClientOutput.java
+++ b/common/src/main/java/org/jboss/fuse/mvnd/common/logging/ClientOutput.java
@@ -36,4 +36,6 @@ public interface ClientOutput extends AutoCloseable {
 
     void keepAlive();
 
+    void buildStatus(String status);
+
 }

--- a/daemon/src/main/java/org/jboss/fuse/mvnd/plugin/CliPluginRealmCache.java
+++ b/daemon/src/main/java/org/jboss/fuse/mvnd/plugin/CliPluginRealmCache.java
@@ -38,11 +38,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.enterprise.inject.Default;
 import javax.inject.Named;
 import javax.inject.Singleton;
-
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.eventspy.AbstractEventSpy;


### PR DESCRIPTION
* Say 'Looking for daemon...' straight ahead to elliminate the initial lag
* Present 'hidden' threads along with used/max threads instead of 'n more'
* Print project name in bold even if no mojo is present in the line
* Be consistent about printing project artifactIds in bold also when lines are hidden
* The rich status line is present also when lines are hidden