### PR TITLE
Make TerminalOutput.dumb final, activate TerminalOutput.noBuffering with -B/--batch-mode, mvnd.rollingWindowSize default 0

### DIFF
--- a/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
+++ b/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
@@ -49,6 +49,7 @@ public class DefaultClient implements Client {
 
         Path logFile = null;
         int i = 0;
+        boolean batchMode = false;
         while (i < argv.length) {
             final String arg = argv[i++];
             if ("-l".equals(arg) || "--log-file".equals(arg)) {
@@ -58,12 +59,15 @@ public class DefaultClient implements Client {
                     throw new IllegalArgumentException("-l and --log-file need to be followed by a path");
                 }
             } else {
+                if (!batchMode && ("-B".equals(arg) || "--batch-mode".equals(arg))) {
+                    batchMode = true;
+                }
                 args.add(arg);
             }
         }
 
         DaemonParameters parameters = new DaemonParameters();
-        try (TerminalOutput output = new TerminalOutput(parameters.noBuffering(), parameters.rollingWindowSize(), logFile)) {
+        try (TerminalOutput output = new TerminalOutput(batchMode || parameters.noBuffering(), parameters.rollingWindowSize(), logFile)) {
             try {
                 new DefaultClient(parameters).execute(output, args);
             } catch (DaemonException.InterruptedException e) {

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -61,7 +61,7 @@ public enum Environment {
     MVND_DAEMON_STORAGE("mvnd.daemon.storage", null, null, false),
     /**
      * Property that can be set to avoid buffering the output and display events continuously, closer to the usual maven
-     * display.
+     * display. Passing {@code -B} or {@code --batch-mode} on the command line enables this too for the given build.
      */
     MVND_NO_BUFERING("mvnd.noBuffering", null, "false", false),
     /**
@@ -101,7 +101,7 @@ public enum Environment {
     },
     /**
      * The maven builder name to use. Ignored if the user passes
-     * 
+     *
      * @{@code -b} or @{@code --builder} on the command line
      */
     MVND_BUILDER("mvnd.builder", null, "smart", false) {

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -65,9 +65,9 @@ public enum Environment {
      */
     MVND_NO_BUFERING("mvnd.noBuffering", null, "false", false),
     /**
-     * The size of the rolling window
+     * The number of log lines to display for each Maven module that is built in parallel.
      */
-    MVND_ROLLING_WINDOW_SIZE("mvnd.rollingWindowSize", null, "2", false),
+    MVND_ROLLING_WINDOW_SIZE("mvnd.rollingWindowSize", null, "0", false),
     /**
      * The path to the daemon registry
      */

--- a/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/logging/TerminalOutput.java
@@ -66,6 +66,7 @@ public class TerminalOutput implements ClientOutput {
     private volatile boolean closing;
     private final long start;
     private final ReadWriteLock readInput = new ReentrantReadWriteLock();
+    private final boolean dumb;
 
     /** A sink for sending messages back to the daemon */
     private volatile Consumer<Message> daemonDispatch;
@@ -91,7 +92,6 @@ public class TerminalOutput implements ClientOutput {
     private String buildStatus;
     private boolean displayDone = false;
     private boolean noBuffering;
-    private boolean dumb;
 
     /**
      * {@link Project} is owned by the display loop thread and is accessed only from there. Therefore it does not need


### PR DESCRIPTION
@gnodet I must say I do not like how rollingWindowSize defaulting to 2 looks on my machine with many processors. I propose to keep the default at 0 for now and discuss in a new issue how we will proceed. I have a couple of ideas how it could work.