### PR TITLE
Right-pad projectIds to improve mojo readability in the threaded view 

### DIFF
--- a/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
+++ b/client/src/main/java/org/mvndaemon/mvnd/client/DefaultClient.java
@@ -231,7 +231,6 @@ public class DefaultClient implements Client {
             try (DaemonClientConnection daemon = connector.connect(output)) {
                 output.setDaemonDispatch(daemon::dispatch);
                 output.setDaemonReceive(daemon::enqueue);
-                output.accept(Message.buildStatus("Connected to daemon"));
 
                 daemon.dispatch(new Message.BuildRequest(
                         args,
@@ -239,7 +238,7 @@ public class DefaultClient implements Client {
                         parameters.multiModuleProjectDirectory().toString(),
                         System.getenv()));
 
-                output.accept(Message.buildStatus("Build request sent"));
+                output.accept(Message.buildStatus("Daemon started, scanning for projects..."));
 
                 // We've sent the request, so it gives us a bit of time to purge the logs
                 AtomicReference<String> purgeMessage = new AtomicReference<>();

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/MultiModuleTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/MultiModuleTest.java
@@ -31,6 +31,7 @@ import org.mvndaemon.mvnd.client.Client;
 import org.mvndaemon.mvnd.client.DaemonParameters;
 import org.mvndaemon.mvnd.common.Message;
 import org.mvndaemon.mvnd.common.Message.ProjectEvent;
+import org.mvndaemon.mvnd.common.Message.StringMessage;
 import org.mvndaemon.mvnd.junit.MvndTest;
 import org.mvndaemon.mvnd.junit.TestUtils;
 
@@ -97,7 +98,7 @@ public class MultiModuleTest {
         {
             final List<String> filteredMessages = output.getMessages().stream()
                     .filter(m -> m.getType() == Message.PROJECT_STARTED)
-                    .map(m -> ((ProjectEvent) m).getProjectId())
+                    .map(m -> ((StringMessage) m).getMessage())
                     .collect(Collectors.toList());
 
             Assertions.assertThat(filteredMessages)

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/MvndTestUtil.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/MvndTestUtil.java
@@ -29,10 +29,6 @@ public class MvndTestUtil {
     private MvndTestUtil() {
     }
 
-    public static String plugin(Properties props, String artifactId) {
-        return artifactId + ":" + props.getProperty(artifactId + ".version");
-    }
-
     public static Properties properties(Path pomXmlPath) {
         try (Reader runtimeReader = Files.newBufferedReader(pomXmlPath, StandardCharsets.UTF_8)) {
             final MavenXpp3Reader rxppReader = new MavenXpp3Reader();

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/SingleModuleNativeIT.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/SingleModuleNativeIT.java
@@ -55,7 +55,7 @@ public class SingleModuleNativeIT {
         Assertions.assertThat(installedJar).doesNotExist();
 
         final TestClientOutput o = new TestClientOutput();
-        client.execute(o, "clean", "install", "-e").assertSuccess();
+        client.execute(o, "clean", "install", "-e", "-B").assertSuccess();
         final Properties props = MvndTestUtil.properties(parameters.multiModuleProjectDirectory().resolve("pom.xml"));
 
         final List<String> messages = o.getMessages().stream()
@@ -65,11 +65,13 @@ public class SingleModuleNativeIT {
         Assertions.assertThat(messages)
                 .is(new MatchInOrderAmongOthers<>(
                         "Building single-module",
-                        MvndTestUtil.plugin(props, "maven-clean-plugin") + ":clean",
-                        MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":compile",
-                        MvndTestUtil.plugin(props, "maven-compiler-plugin") + ":testCompile",
-                        MvndTestUtil.plugin(props, "maven-surefire-plugin") + ":test",
-                        MvndTestUtil.plugin(props, "maven-install-plugin") + ":install",
+                        mojoStartedLogMessage(props, "maven-clean-plugin", "clean", "default-clean"),
+                        mojoStartedLogMessage(props, "maven-resources-plugin", "resources", "default-resources"),
+                        mojoStartedLogMessage(props, "maven-compiler-plugin", "compile", "default-compile"),
+                        mojoStartedLogMessage(props, "maven-resources-plugin", "testResources", "default-testResources"),
+                        mojoStartedLogMessage(props, "maven-compiler-plugin", "testCompile", "default-testCompile"),
+                        mojoStartedLogMessage(props, "maven-surefire-plugin", "test", "default-test"),
+                        mojoStartedLogMessage(props, "maven-install-plugin", "install", "default-install"),
                         "BUILD SUCCESS"));
 
         assertJVM(o, props);
@@ -84,4 +86,10 @@ public class SingleModuleNativeIT {
     protected void assertJVM(TestClientOutput o, Properties props) {
         /* implemented in the subclass */
     }
+
+    String mojoStartedLogMessage(Properties props, String pluginArtifactId, String mojo, String executionId) {
+        return "\\Q--- " + pluginArtifactId + ":" + props.getProperty(pluginArtifactId + ".version") + ":" + mojo + " ("
+                + executionId + ") @ single-module ---\\E";
+    }
+
 }

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/SingleModuleTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/SingleModuleTest.java
@@ -35,21 +35,19 @@ public class SingleModuleTest extends SingleModuleNativeIT {
 
         Assertions.assertThat(filteredMessages)
                 .is(new MatchInOrderAmongOthers<>(
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-clean-plugin")
-                                + ":clean {execution: default-clean}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-resources-plugin")
-                                + ":resources {execution: default-resources}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-compiler-plugin")
-                                + ":compile {execution: default-compile}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-resources-plugin")
-                                + ":testResources {execution: default-testResources}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-compiler-plugin")
-                                + ":testCompile {execution: default-testCompile}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-surefire-plugin")
-                                + ":test {execution: default-test}\\E",
-                        "\\Q:single-module:org.apache.maven.plugins:" + MvndTestUtil.plugin(props, "maven-install-plugin")
-                                + ":install {execution: default-install}\\E"));
+                        mojoStarted(props, "maven-clean-plugin", "clean", "default-clean"),
+                        mojoStarted(props, "maven-resources-plugin", "resources", "default-resources"),
+                        mojoStarted(props, "maven-compiler-plugin", "compile", "default-compile"),
+                        mojoStarted(props, "maven-resources-plugin", "testResources", "default-testResources"),
+                        mojoStarted(props, "maven-compiler-plugin", "testCompile", "default-testCompile"),
+                        mojoStarted(props, "maven-surefire-plugin", "test", "default-test"),
+                        mojoStarted(props, "maven-install-plugin", "install", "default-install")));
 
+    }
+
+    String mojoStarted(Properties props, String pluginArtifactId, String mojo, String executionId) {
+        return "\\Q" + Message.mojoStarted("single-module", "org.apache.maven.plugins", pluginArtifactId,
+                props.getProperty(pluginArtifactId + ".version"), mojo, executionId).toString() + "\\E";
     }
 
 }


### PR DESCRIPTION
Fix #288

This PR depends on PR https://github.com/mvndaemon/mvnd/pull/285 , but the idea in itself is independent. In case you veto #285 @gnodet , I can rebase this. 

Once again, this is how it looks like: 
![image](https://user-images.githubusercontent.com/1826249/103141484-13ea8300-46f5-11eb-85fc-f4c2582c2598.png)
