### PR TITLE
Correct brew installation command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,7 +58,7 @@ sense. With SDKMAN!, the `~/.m2/mvnd.properties` file is typically not needed at
 
 [source,shell]
 ----
-$ brew install mvndaemon/homebrew-mvnd/mvnd
+$ brew install --HEAD mvndaemon/homebrew-mvnd/mvnd
 ----
 
 === Set up completion


### PR DESCRIPTION
The example doesn't work:
```console
$ brew install mvndaemon/homebrew-mvnd/mvnd
==> Tapping mvndaemon/mvnd
Cloning into '/usr/local/Homebrew/Library/Taps/mvndaemon/homebrew-mvnd'...
remote: Enumerating objects: 81, done.
remote: Counting objects: 100% (81/81), done.
remote: Compressing objects: 100% (43/43), done.
remote: Total 81 (delta 34), reused 66 (delta 21), pack-reused 0
Unpacking objects: 100% (81/81), done.
Tapped 1 formula (109 files, 81.3KB).
Error: mvndaemon/mvnd/mvnd is a head-only formula
Install with `brew install --HEAD mvndaemon/mvnd/mvnd`
```