### PR TITLE
[DONT MERGE] inheritIO issue

### DIFF
--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/JUnitPlatformTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/JUnitPlatformTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.it;
+
+import org.junit.jupiter.api.Test;
+import org.mvndaemon.mvnd.assertj.TestClientOutput;
+import org.mvndaemon.mvnd.client.Client;
+import org.mvndaemon.mvnd.client.DaemonParameters;
+import org.mvndaemon.mvnd.common.Message;
+import org.mvndaemon.mvnd.junit.MvndTest;
+
+import javax.inject.Inject;
+
+import static junit.framework.Assert.assertTrue;
+
+@MvndTest(projectDir = "src/test/projects/junit-platform")
+public class JUnitPlatformTest {
+
+    @Inject
+    Client client;
+
+    @Inject
+    DaemonParameters parameters;
+
+    @Test
+    void cleanTestInheritIO() throws InterruptedException {
+
+        final TestClientOutput output = new TestClientOutput();
+        client.execute(output, "clean", "test", "-e", "-Dmvnd.log.level=DEBUG", "-DinheritIO=true").assertSuccess();
+        assertHasTestMessage(output);
+
+    }
+
+    @Test
+    void cleanTestDontInheritIO() throws InterruptedException {
+
+        final TestClientOutput output = new TestClientOutput();
+        client.execute(output, "clean", "test", "-e", "-Dmvnd.log.level=DEBUG", "-DinheritIO=false").assertSuccess();
+        assertHasTestMessage(output);
+
+    }
+
+    private void assertHasTestMessage(final TestClientOutput output) {
+        assertTrue(output.getMessages().stream()
+                .filter(Message.ProjectEvent.class::isInstance)
+                .map(Message.ProjectEvent.class::cast)
+                .anyMatch(it -> it.getMessage() != null &&
+                        "From test".equals(it.getMessage().replaceFirst(".*] ", ""))));
+    }
+}

--- a/integration-tests/src/test/projects/junit-platform/.mvn/maven.config
+++ b/integration-tests/src/test/projects/junit-platform/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.retryHandler.count=10

--- a/integration-tests/src/test/projects/junit-platform/pom.xml
+++ b/integration-tests/src/test/projects/junit-platform/pom.xml
@@ -1,0 +1,109 @@
+<!--
+
+    Copyright 2019 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mvndaemon.mvnd.test.exec-output</groupId>
+    <artifactId>jp-output</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+
+        <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-install-plugin.version>2.4</maven-install-plugin.version>
+        <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-maven-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>de.sormuras.junit</groupId>
+                <artifactId>junit-platform-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <isolation>NONE</isolation>
+                    <executor>JAVA</executor>
+                    <javaOptions>
+                        <inheritIO>${inheritIO}</inheritIO>
+                        <additionalLauncherOptions>
+                            <additionalLauncherOption>--disable-banner</additionalLauncherOption>
+                        </additionalLauncherOptions>
+                    </javaOptions>
+                    <tweaks>
+                        <failIfNoTests>false</failIfNoTests>
+                        <details>flat</details>
+                    </tweaks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/src/test/projects/junit-platform/src/test/java/org/mvndaemon/mvnd/test/GreetingTest.java
+++ b/integration-tests/src/test/projects/junit-platform/src/test/java/org/mvndaemon/mvnd/test/GreetingTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.test;
+
+import org.junit.jupiter.api.Test;
+
+class GreetingTest {
+
+    @Test
+    void run() {
+        System.out.println("From test");
+    }
+
+}


### PR DESCRIPTION
PR to show the issue with several plugins using inherit IO fork (and more precisely a way to reproduce it in IT module).

Question is now: do we go with agent option? It can intercept inheritIO and trigger redirect to file instead of poll them, or just use the process streams maybe?