### PR TITLE
Eliminate mutable global state in AbstractLoggingSpy

### DIFF
--- a/daemon/src/main/java/org/mvndaemon/mvnd/logging/smart/AbstractLoggingSpy.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/logging/smart/AbstractLoggingSpy.java
@@ -15,83 +15,91 @@
  */
 package org.mvndaemon.mvnd.logging.smart;
 
+import java.util.Collection;
+import java.util.function.Consumer;
 import org.apache.maven.execution.ExecutionEvent;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.mvndaemon.mvnd.builder.DependencyGraph;
+import org.mvndaemon.mvnd.common.Message;
+import org.mvndaemon.mvnd.common.Message.BuildException;
+import org.mvndaemon.mvnd.common.Message.BuildStarted;
 
-public abstract class AbstractLoggingSpy {
+/**
+ * Sends events back to the client.
+ */
+public class AbstractLoggingSpy {
+    private static final AbstractLoggingSpy DUMMY = new AbstractLoggingSpy(m -> {
+    });
+    private final Consumer<Message> queue;
 
-    private static AbstractLoggingSpy instance;
-
-    public static AbstractLoggingSpy instance() {
-        if (instance == null) {
-            instance = new AbstractLoggingSpy() {
-            };
-        }
-        return instance;
+    /**
+     * @return a dummy {@link AbstractLoggingSpy} that just swallows the messages and does not send them anywhere
+     */
+    public static AbstractLoggingSpy dummy() {
+        return DUMMY;
     }
 
-    public static void instance(AbstractLoggingSpy instance) {
-        AbstractLoggingSpy.instance = instance;
+    public AbstractLoggingSpy(Collection<Message> queue) {
+        this(queue::add);
     }
 
-    public void append(String event) {
-        append(null, event);
+    public AbstractLoggingSpy(Consumer<Message> queue) {
+        this.queue = queue;
     }
 
-    public void append(String projectId, String event) {
+    public void sessionStarted(ExecutionEvent event) {
+        final MavenSession session = event.getSession();
+        final int degreeOfConcurrency = session.getRequest().getDegreeOfConcurrency();
+        final DependencyGraph<MavenProject> dependencyGraph = DependencyGraph.fromMaven(session);
+        session.getRequest().getData().put(DependencyGraph.class.getName(), dependencyGraph);
+
+        final int maxThreads = degreeOfConcurrency == 1 ? 1 : dependencyGraph.computeMaxWidth(degreeOfConcurrency, 1000);
+        queue.accept(new BuildStarted(getCurrentProject(session).getName(), session.getProjects().size(), maxThreads));
+    }
+
+    public void projectStarted(ExecutionEvent event) {
+        queue.accept(Message.projectStarted(getProjectId(event), getProjectDisplay(event)));
+    }
+
+    public void projectLogMessage(String projectId, String event) {
         String msg = event.endsWith("\n") ? event.substring(0, event.length() - 1) : event;
-        onProjectLog(projectId, msg);
+        queue.accept(projectId == null ? Message.log(msg) : Message.log(projectId, msg));
+    }
+
+    public void projectFinished(ExecutionEvent event) {
+        queue.accept(Message.projectStopped(getProjectId(event), getProjectDisplay(event)));
+    }
+
+    public void mojoStarted(ExecutionEvent event) {
+        queue.accept(Message.mojoStarted(getProjectId(event), getProjectDisplay(event)));
     }
 
     public void finish(int exitCode) throws Exception {
+        queue.accept(new Message.BuildFinished(exitCode));
+        queue.accept(Message.STOP_SINGLETON);
     }
 
     public void fail(Throwable t) throws Exception {
+        queue.accept(new BuildException(t));
+        queue.accept(Message.STOP_SINGLETON);
     }
 
-    protected void notifySessionStart(ExecutionEvent event) {
-        onStartSession(event.getSession());
+    public void log(String msg) {
+        queue.accept(Message.log(msg));
     }
 
-    protected void notifySessionFinish(ExecutionEvent event) {
-        onFinishSession();
-    }
-
-    protected void notifyProjectBuildStart(ExecutionEvent event) {
-        onStartProject(getProjectId(event), getProjectDisplay(event));
-    }
-
-    protected void notifyProjectBuildFinish(ExecutionEvent event) {
-        onStopProject(getProjectId(event), getProjectDisplay(event));
-    }
-
-    protected void notifyMojoExecutionStart(ExecutionEvent event) {
-        onStartMojo(getProjectId(event), getProjectDisplay(event));
-    }
-
-    protected void notifyMojoExecutionFinish(ExecutionEvent event) {
-        onStopMojo(getProjectId(event), getProjectDisplay(event));
-    }
-
-    protected void onStartSession(MavenSession session) {
-    }
-
-    protected void onFinishSession() {
-    }
-
-    protected void onStartProject(String projectId, String display) {
-    }
-
-    protected void onStopProject(String projectId, String display) {
-    }
-
-    protected void onStartMojo(String projectId, String display) {
-    }
-
-    protected void onStopMojo(String projectId, String display) {
-    }
-
-    protected void onProjectLog(String projectId, String message) {
+    private MavenProject getCurrentProject(MavenSession mavenSession) {
+        // Workaround for https://issues.apache.org/jira/browse/MNG-6979
+        // MavenSession.getCurrentProject() does not return the correct value in some cases
+        String executionRootDirectory = mavenSession.getExecutionRootDirectory();
+        if (executionRootDirectory == null) {
+            return mavenSession.getCurrentProject();
+        }
+        return mavenSession.getProjects().stream()
+                .filter(p -> (p.getFile() != null && executionRootDirectory.equals(p.getFile().getParent())))
+                .findFirst()
+                .orElse(mavenSession.getCurrentProject());
     }
 
     private String getProjectId(ExecutionEvent event) {

--- a/daemon/src/main/java/org/mvndaemon/mvnd/logging/smart/LoggingExecutionListener.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/logging/smart/LoggingExecutionListener.java
@@ -21,9 +21,11 @@ import org.apache.maven.execution.ExecutionListener;
 public class LoggingExecutionListener implements ExecutionListener {
 
     private final ExecutionListener delegate;
+    private final AbstractLoggingSpy loggingSpy;
 
-    public LoggingExecutionListener(ExecutionListener delegate) {
+    public LoggingExecutionListener(ExecutionListener delegate, AbstractLoggingSpy loggingSpy) {
         this.delegate = delegate;
+        this.loggingSpy = loggingSpy;
     }
 
     @Override
@@ -35,7 +37,7 @@ public class LoggingExecutionListener implements ExecutionListener {
     @Override
     public void sessionStarted(ExecutionEvent event) {
         setMdc(event);
-        AbstractLoggingSpy.instance().notifySessionStart(event);
+        loggingSpy.sessionStarted(event);
         delegate.sessionStarted(event);
     }
 
@@ -43,13 +45,12 @@ public class LoggingExecutionListener implements ExecutionListener {
     public void sessionEnded(ExecutionEvent event) {
         setMdc(event);
         delegate.sessionEnded(event);
-        AbstractLoggingSpy.instance().notifySessionFinish(event);
     }
 
     @Override
     public void projectStarted(ExecutionEvent event) {
         setMdc(event);
-        AbstractLoggingSpy.instance().notifyProjectBuildStart(event);
+        loggingSpy.projectStarted(event);
         delegate.projectStarted(event);
     }
 
@@ -57,27 +58,27 @@ public class LoggingExecutionListener implements ExecutionListener {
     public void projectSucceeded(ExecutionEvent event) {
         setMdc(event);
         delegate.projectSucceeded(event);
-        AbstractLoggingSpy.instance().notifyProjectBuildFinish(event);
+        loggingSpy.projectFinished(event);
     }
 
     @Override
     public void projectFailed(ExecutionEvent event) {
         setMdc(event);
         delegate.projectFailed(event);
-        AbstractLoggingSpy.instance().notifyProjectBuildFinish(event);
+        loggingSpy.projectFinished(event);
     }
 
     @Override
     public void projectSkipped(ExecutionEvent event) {
         setMdc(event);
         delegate.projectSkipped(event);
-        AbstractLoggingSpy.instance().notifyProjectBuildFinish(event);
+        loggingSpy.projectFinished(event);
     }
 
     @Override
     public void mojoStarted(ExecutionEvent event) {
         setMdc(event);
-        AbstractLoggingSpy.instance().notifyMojoExecutionStart(event);
+        loggingSpy.mojoStarted(event);
         delegate.mojoStarted(event);
     }
 
@@ -85,21 +86,18 @@ public class LoggingExecutionListener implements ExecutionListener {
     public void mojoSucceeded(ExecutionEvent event) {
         setMdc(event);
         delegate.mojoSucceeded(event);
-        AbstractLoggingSpy.instance().notifyMojoExecutionFinish(event);
     }
 
     @Override
     public void mojoFailed(ExecutionEvent event) {
         setMdc(event);
         delegate.mojoFailed(event);
-        AbstractLoggingSpy.instance().notifyMojoExecutionFinish(event);
     }
 
     @Override
     public void mojoSkipped(ExecutionEvent event) {
         setMdc(event);
         delegate.mojoSkipped(event);
-        AbstractLoggingSpy.instance().notifyMojoExecutionFinish(event);
     }
 
     @Override

--- a/dist/src/main/distro/conf/logback.xml
+++ b/dist/src/main/distro/conf/logback.xml
@@ -25,13 +25,6 @@
 <configuration>
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator" />
 
-  <!--
-    | write project-specific build log messages to ${project.build.directory}/build.log files
-   -->
-  <appender name="MEM" class="org.mvndaemon.mvnd.logging.smart.ProjectBuildLogAppender">
-    <pattern>[%level] %msg%n</pattern>
-  </appender>
-
   <appender name="DAEMON" class="ch.qos.logback.core.FileAppender">
     <file>${mvnd.daemonStorage}/daemon-${mvnd.uid}.log</file>
     <encoder>
@@ -49,7 +42,4 @@
   <logger name="org.apache.maven.lifecycle.internal.builder.BuilderCommon" level="ERROR" />
   <logger name="org.eclipse.aether.internal.impl.WarnChecksumPolicy" level="ERROR" />
 
-  <root level="${consoleLevel:-info}">
-    <appender-ref ref="MEM" />
-  </root>
 </configuration>


### PR DESCRIPTION
This is the second commit from https://github.com/mvndaemon/mvnd/pull/285, simplified and without renaming and moving AbstractLoggingSpy so that it is easier to follow what it does. Could you please review, @gnodet ?