### PR TITLE
Leverage Maven's -Dstyle.color to avoid coloring instead of stripping the ASCII codes in the client

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -173,6 +173,10 @@ $ ls -lh target/mvnd
 
 === Known issues and limitations
 
-* Parallel build, hence `mvnd`, don't play well with `-rf` maven option at the moment. If you use the `-rf` maven option with `mvnd` you have no guarantee that all the modules will have been built (There are some improvements planned on this in the next `mvnd` releases).
+* `mvnd` generally does not play well with `-rf` Maven option at the moment.
+  If your source tree allows for building of some modules in parallel
+  and if the failure happens on some of the parallel execution branches,
+  there is no guarantee that `mvnd` builds all modules skipped due to the previous failure.
+  There are some improvements planned on this in the next `mvnd` releases.
 
-We're happy to improve `mvnd`, so feedback is most welcomed!
+We're happy to improve `mvnd`, so https://github.com/mvndaemon/mvnd/issues[feedback] is most welcomed!

--- a/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/Environment.java
@@ -473,6 +473,17 @@ public enum Environment {
         }
     }
 
+    /**
+     * The values of {@link Environment#MAVEN_COLOR} option.
+     */
+    public enum Color {
+        always, never, auto;
+
+        public static Optional<Color> of(String color) {
+            return color == null ? Optional.empty() : Optional.of(Color.valueOf(color));
+        }
+    }
+
     public static class DocumentedEnumEntry<E> {
 
         private final E entry;

--- a/daemon/src/test/java/org/mvndaemon/mvnd/cache/impl/CacheFactoryTest.java
+++ b/daemon/src/test/java/org/mvndaemon/mvnd/cache/impl/CacheFactoryTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -63,6 +64,12 @@ public class CacheFactoryTest {
         Assertions.assertTrue(cache.contains(k2));
         Assertions.assertEquals(record2, cache.get(k2));
         Assertions.assertFalse(record2.invalidated);
+
+        /* Make sure the new content is written a couple of ms later than the original lastModifiedTime */
+        final long deadline = Files.readAttributes(file1, BasicFileAttributes.class).lastModifiedTime().toMillis() + 10;
+        while (System.currentTimeMillis() < deadline) {
+            Thread.sleep(1);
+        }
 
         Files.write(file1, "content1.1".getBytes(StandardCharsets.UTF_8));
         if (asyncOpDelayMs > 0) {

--- a/daemon/src/test/java/org/mvndaemon/mvnd/daemon/ServerTest.java
+++ b/daemon/src/test/java/org/mvndaemon/mvnd/daemon/ServerTest.java
@@ -18,7 +18,6 @@ package org.mvndaemon.mvnd.daemon;
 import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.PriorityBlockingQueue;
-
 import org.junit.jupiter.api.Test;
 import org.mvndaemon.mvnd.common.Message;
 
@@ -32,8 +31,7 @@ public class ServerTest {
         messages.addAll(Arrays.asList(
                 Message.projectStopped("projectId"),
                 Message.projectStarted("projectId"),
-                Message.log("projectId", "message"))
-        );
+                Message.log("projectId", "message")));
 
         assertEquals(Message.PROJECT_STARTED, messages.remove().getType());
         assertEquals(Message.PROJECT_LOG_MESSAGE, messages.remove().getType());

--- a/dist/src/main/distro/bin/mvnd-bash-completion.bash
+++ b/dist/src/main/distro/bin/mvnd-bash-completion.bash
@@ -146,8 +146,8 @@ _mvnd()
     _get_comp_words_by_ref -n : cur prev
 
     local mvnd_opts="-1"
-    local mvnd_long_opts="--color|--completion|--purge|--serial|--status|--stop"
-    local mvnd_properties="-Djava.home|-Dmaven.multiModuleProjectDirectory|-Dmaven.repo.local|-Dmaven.settings|-Dmvnd.builder|-Dmvnd.daemonStorage|-Dmvnd.debug|-Dmvnd.duplicateDaemonGracePeriod|-Dmvnd.enableAssertions|-Dmvnd.expirationCheckDelay|-Dmvnd.home|-Dmvnd.idleTimeout|-Dmvnd.jvmArgs|-Dmvnd.keepAlive|-Dmvnd.logPurgePeriod|-Dmvnd.logback|-Dmvnd.maxHeapSize|-Dmvnd.maxLostKeepAlive|-Dmvnd.minHeapSize|-Dmvnd.minThreads|-Dmvnd.noBuffering|-Dmvnd.noDaemon|-Dmvnd.propertiesPath|-Dmvnd.registry|-Dmvnd.rollingWindowSize|-Dmvnd.serial|-Dmvnd.threads|-Duser.dir|-Duser.home"
+    local mvnd_long_opts="--completion|--purge|--serial|--status|--stop"
+    local mvnd_properties="-Djava.home|-Dmaven.multiModuleProjectDirectory|-Dmaven.repo.local|-Dmaven.settings|-Dmvnd.builder|-Dmvnd.daemonStorage|-Dmvnd.debug|-Dmvnd.duplicateDaemonGracePeriod|-Dmvnd.enableAssertions|-Dmvnd.expirationCheckDelay|-Dmvnd.home|-Dmvnd.idleTimeout|-Dmvnd.jvmArgs|-Dmvnd.keepAlive|-Dmvnd.logPurgePeriod|-Dmvnd.logback|-Dmvnd.maxHeapSize|-Dmvnd.maxLostKeepAlive|-Dmvnd.minHeapSize|-Dmvnd.minThreads|-Dmvnd.noBuffering|-Dmvnd.noDaemon|-Dmvnd.propertiesPath|-Dmvnd.registry|-Dmvnd.rollingWindowSize|-Dmvnd.serial|-Dmvnd.threads|-Dstyle.color|-Duser.dir|-Duser.home"
     local opts="-am|-amd|-B|-C|-c|-cpu|-D|-e|-emp|-ep|-f|-fae|-ff|-fn|-gs|-h|-l|-N|-npr|-npu|-nsu|-o|-P|-pl|-q|-rf|-s|-T|-t|-U|-up|-V|-v|-X|${mvnd_opts}"
     local long_opts="--also-make|--also-make-dependents|--batch-mode|--strict-checksums|--lax-checksums|--check-plugin-updates|--define|--errors|--encrypt-master-password|--encrypt-password|--file|--fail-at-end|--fail-fast|--fail-never|--global-settings|--help|--log-file|--non-recursive|--no-plugin-registry|--no-plugin-updates|--no-snapshot-updates|--offline|--activate-profiles|--projects|--quiet|--resume-from|--settings|--threads|--toolchains|--update-snapshots|--update-plugins|--show-version|--version|--debug|${mvnd_long_opts}"
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -38,6 +38,7 @@
             org/apache/maven/surefire/surefire-junit-platform/${surefire.version}
             org/junit/platform/junit-platform-launcher/${junit-platform-launcher.version}
             org/junit/platform/junit-platform-engine/${junit-platform-launcher.version}
+            org/junit/platform/junit-platform-commons/${junit-platform-launcher.version}
             org/junit/jupiter/junit-jupiter/${junit.jupiter.version}
             org/junit/jupiter/junit-jupiter-api/${junit.jupiter.version}
         </preinstall.artifacts>

--- a/integration-tests/src/test/java/org/mvndaemon/mvnd/it/EnvironmentTest.java
+++ b/integration-tests/src/test/java/org/mvndaemon/mvnd/it/EnvironmentTest.java
@@ -53,6 +53,9 @@ public class EnvironmentTest {
             cl.execute(output, "org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate",
                     "-Dexpression=user.dir", "-e").assertSuccess();
             assertDaemonRegistrySize(1);
+            /* Wait, till the existing instance becomes idle so that the next iteration does not start a new instance */
+            registry.awaitIdle(registry.getAll().get(0).getId());
+
             String pathStr = dir.toAbsolutePath().toString();
             assertTrue(output.getMessages().stream()
                     .anyMatch(m -> m.toString().contains(pathStr)), "Output should contain " + pathStr);


### PR DESCRIPTION
Fix #373 