### PR TITLE
#390 Restrict usage of mvnd daemons to the current user by utilizing a token check

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/DaemonInfo.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/DaemonInfo.java
@@ -26,11 +26,14 @@ import static org.mvndaemon.mvnd.common.DaemonState.Idle;
  */
 public class DaemonInfo {
 
+    public static final int TOKEN_SIZE = 16;
+
     private final String id;
     private final String javaHome;
     private final String mvndHome;
     private final int pid;
     private final int address;
+    private final byte[] token;
     private final String locale;
     private final List<String> options;
     private final DaemonState state;
@@ -38,7 +41,7 @@ public class DaemonInfo {
     private final long lastBusy;
 
     public DaemonInfo(String id, String javaHome, String mavenHome,
-            int pid, int address,
+            int pid, int address, byte[] token,
             String locale, List<String> options,
             DaemonState state, long lastIdle, long lastBusy) {
         this.id = id;
@@ -46,6 +49,7 @@ public class DaemonInfo {
         this.mvndHome = mavenHome;
         this.pid = pid;
         this.address = address;
+        this.token = token;
         this.locale = locale;
         this.options = options;
         this.state = state;
@@ -71,6 +75,10 @@ public class DaemonInfo {
 
     public int getAddress() {
         return address;
+    }
+
+    public byte[] getToken() {
+        return token;
     }
 
     public String getLocale() {
@@ -106,7 +114,7 @@ public class DaemonInfo {
             lb = lastBusy;
         }
         return new DaemonInfo(id, javaHome, mvndHome, pid, address,
-                locale, options, state, li, lb);
+                token, locale, options, state, li, lb);
     }
 
     @Override

--- a/common/src/main/java/org/mvndaemon/mvnd/common/DaemonRegistry.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/DaemonRegistry.java
@@ -181,6 +181,10 @@ public class DaemonRegistry implements AutoCloseable {
                         String mavenHome = readString();
                         int pid = buffer.getInt();
                         int address = buffer.getInt();
+
+                        byte[] token = new byte[DaemonInfo.TOKEN_SIZE];
+                        buffer.get(token);
+
                         String locale = readString();
                         List<String> opts = new ArrayList<>();
                         int nbOpts = buffer.getInt();
@@ -190,8 +194,8 @@ public class DaemonRegistry implements AutoCloseable {
                         DaemonState state = DaemonState.values()[buffer.get()];
                         long lastIdle = buffer.getLong();
                         long lastBusy = buffer.getLong();
-                        DaemonInfo di = new DaemonInfo(daemonId, javaHome, mavenHome, pid, address, locale, opts, state,
-                                lastIdle, lastBusy);
+                        DaemonInfo di = new DaemonInfo(daemonId, javaHome, mavenHome, pid, address, token, locale,
+                                opts, state, lastIdle, lastBusy);
                         infosMap.putIfAbsent(di.getId(), di);
                     }
                     stopEvents.clear();
@@ -216,6 +220,7 @@ public class DaemonRegistry implements AutoCloseable {
                             writeString(di.getMvndHome());
                             buffer.putInt(di.getPid());
                             buffer.putInt(di.getAddress());
+                            buffer.put(di.getToken());
                             writeString(di.getLocale());
                             buffer.putInt(di.getOptions().size());
                             for (String opt : di.getOptions()) {

--- a/common/src/test/java/org/mvndaemon/mvnd/common/DaemonRegistryTest.java
+++ b/common/src/test/java/org/mvndaemon/mvnd/common/DaemonRegistryTest.java
@@ -41,7 +41,7 @@ public class DaemonRegistryTest {
             byte[] token = new byte[16];
             new Random().nextBytes(token);
             reg1.store(new DaemonInfo("12345678", "/java/home/",
-                    "/data/reg/", 0x12345678, 7502,
+                    "/data/reg/", 0x12345678, 7502, token,
                     Locale.getDefault().toLanguageTag(), Arrays.asList("-Xmx"),
                     DaemonState.Idle, System.currentTimeMillis(), System.currentTimeMillis()));
 


### PR DESCRIPTION
Adds a token to the persisted daemon registry, which the client is required to transmit directly after initiating the connection with the daemon.