### PR TITLE
[Proposal] Dispose CL and caches per daemon run

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/ClassLoaderHelper.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/ClassLoaderHelper.java
@@ -25,18 +25,18 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
-public class ClassLoaderHelper {
+public final class ClassLoaderHelper {
 
     private ClassLoaderHelper() {
         // no instances
     }
 
     /**
-     * Creates mvndaemon loader based on mvnd home (and known layout).
+     * Creates mvndaemon class loader based on {@link Environment#MVND_HOME} and known layout.
      *
      * @param  filter non-null filter applied to findClass method.
-     * @param  parent nullable parent classloader.
-     * @return        a {@link ClassLoader} that uses passes in filter and parent.
+     * @param  parent nullable parent class loader.
+     * @return        a built {@link ClassLoader} that uses passed in filter and optionally parent.
      */
     public static ClassLoader createLoader(final Predicate<String> filter, final ClassLoader parent) {
 

--- a/common/src/main/java/org/mvndaemon/mvnd/common/ClassLoaderHelper.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/ClassLoaderHelper.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvndaemon.mvnd.common;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+public class ClassLoaderHelper {
+
+    private ClassLoaderHelper() {
+        // no instances
+    }
+
+    /**
+     * Creates mvndaemon loader based on mvnd home (and known layout).
+     *
+     * @param  filter non-null filter applied to findClass method.
+     * @param  parent nullable parent classloader.
+     * @return        a {@link ClassLoader} that uses passes in filter and parent.
+     */
+    public static ClassLoader createLoader(final Predicate<String> filter, final ClassLoader parent) {
+
+        requireNonNull(filter);
+        final Path mvndHome = Environment.MVND_HOME.asPath();
+        URL[] classpath = Stream.concat(
+                /* jars */
+                Stream.of("mvn/lib/ext", "mvn/lib", "mvn/boot")
+                        .map(mvndHome::resolve)
+                        .flatMap((Path p) -> {
+                            try {
+                                return Files.list(p);
+                            } catch (java.io.IOException e) {
+                                throw new RuntimeException("Could not list " + p, e);
+                            }
+                        })
+                        .filter(p -> {
+                            final String fileName = p.getFileName().toString();
+                            return fileName.endsWith(".jar") && !fileName.startsWith("mvnd-client-");
+                        })
+                        .filter(Files::isRegularFile),
+                /* resources */
+                Stream.of(mvndHome.resolve("mvn/conf"), mvndHome.resolve("mvn/conf/logging")))
+
+                .map(Path::normalize)
+                .map(Path::toUri)
+                .map(uri -> {
+                    try {
+                        return uri.toURL();
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toArray(URL[]::new);
+        return new URLClassLoader(classpath, parent) {
+
+            private final ClassLoader fallback = parent != null ? parent : ClassLoaderHelper.class.getClassLoader();
+
+            @Override
+            protected Class<?> findClass(String name) throws ClassNotFoundException {
+                try {
+                    if (filter.test(name)) {
+                        return super.findClass(name);
+                    }
+                } catch (ClassNotFoundException e) {
+                    return fallback.loadClass(name);
+                }
+                throw new ClassNotFoundException(name);
+            }
+
+            @Override
+            public URL getResource(String name) {
+                URL url = null;
+                if (filter.test(name)) {
+                    url = super.getResource(name);
+                }
+                if (url == null) {
+                    url = fallback.getResource(name);
+                }
+                return url;
+            }
+        };
+    }
+}

--- a/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
@@ -15,66 +15,10 @@
  */
 package org.mvndaemon.mvnd.common;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.stream.Stream;
-
 public class MavenDaemon {
 
     public static void main(String[] args) throws Exception {
-
-        final Path mvndHome = Environment.MVND_HOME.asPath();
-        URL[] classpath = Stream.concat(
-                /* jars */
-                Stream.of("mvn/lib/ext", "mvn/lib", "mvn/boot")
-                        .map(mvndHome::resolve)
-                        .flatMap((Path p) -> {
-                            try {
-                                return Files.list(p);
-                            } catch (java.io.IOException e) {
-                                throw new RuntimeException("Could not list " + p, e);
-                            }
-                        })
-                        .filter(p -> {
-                            final String fileName = p.getFileName().toString();
-                            return fileName.endsWith(".jar") && !fileName.startsWith("mvnd-client-");
-                        })
-                        .filter(Files::isRegularFile),
-                /* resources */
-                Stream.of(mvndHome.resolve("mvn/conf"), mvndHome.resolve("mvn/conf/logging")))
-
-                .map(Path::normalize)
-                .map(Path::toUri)
-                .map(uri -> {
-                    try {
-                        return uri.toURL();
-                    } catch (MalformedURLException e) {
-                        throw new RuntimeException(e);
-                    }
-                })
-                .toArray(URL[]::new);
-        ClassLoader loader = new URLClassLoader(classpath, null) {
-            @Override
-            protected Class<?> findClass(String name) throws ClassNotFoundException {
-                try {
-                    return super.findClass(name);
-                } catch (ClassNotFoundException e) {
-                    return MavenDaemon.class.getClassLoader().loadClass(name);
-                }
-            }
-
-            @Override
-            public URL getResource(String name) {
-                URL url = super.getResource(name);
-                if (url == null) {
-                    url = MavenDaemon.class.getClassLoader().getResource(name);
-                }
-                return url;
-            }
-        };
+        ClassLoader loader = ClassLoaderHelper.createLoader(s -> true, null);
         Thread.currentThread().setContextClassLoader(loader);
         Class<?> clazz = loader.loadClass("org.mvndaemon.mvnd.daemon.Server");
         try (AutoCloseable server = (AutoCloseable) clazz.getConstructor().newInstance()) {

--- a/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/MavenDaemon.java
@@ -15,7 +15,6 @@
  */
 package org.mvndaemon.mvnd.common;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -26,9 +25,6 @@ import java.util.stream.Stream;
 public class MavenDaemon {
 
     public static void main(String[] args) throws Exception {
-        // Disable URL caching so that  the JVM does not try to cache resources
-        // loaded from jars that are built by a previous run
-        new File("txt").toURI().toURL().openConnection().setDefaultUseCaches(false);
 
         final Path mvndHome = Environment.MVND_HOME.asPath();
         URL[] classpath = Stream.concat(

--- a/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
+++ b/daemon/src/main/java/org/mvndaemon/mvnd/daemon/Server.java
@@ -17,8 +17,6 @@ package org.mvndaemon.mvnd.daemon;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
@@ -43,6 +41,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.mvndaemon.mvnd.builder.SmartBuilder;
+import org.mvndaemon.mvnd.common.ClassLoaderHelper;
 import org.mvndaemon.mvnd.common.DaemonConnection;
 import org.mvndaemon.mvnd.common.DaemonException;
 import org.mvndaemon.mvnd.common.DaemonExpirationStatus;
@@ -572,7 +571,8 @@ public class Server implements AutoCloseable, Runnable {
 
                 final ClassLoader original = Thread.currentThread().getContextClassLoader();
                 try {
-                    URLClassLoader disposableClassLoader = new URLClassLoader(new URL[0], original);
+                    ClassLoader disposableClassLoader = ClassLoaderHelper
+                            .createLoader(s -> s.startsWith("org.apache.maven.cli.DaemonMavenCli"), original);
                     Thread.currentThread().setContextClassLoader(disposableClassLoader);
                     Class<?> disposableCliClass = disposableClassLoader.loadClass("org.apache.maven.cli.DaemonMavenCli");
                     int exitCode = (int) disposableCliClass.getMethod(


### PR DESCRIPTION
Coming from here https://github.com/mvndaemon/mvnd/issues/527

Disabling URL connection caches globally is like
using shotgun against a fly.

Instead, re-create a "disposable" classloader per
Maven Daemon CLI run, and clear caches once
done.

This still keeps JVM "warm", but introduces some
penalty to reconstruct maven from scratch, but
will flush things like once loaded extensions,
keeping work more correct.